### PR TITLE
Added missing dev dependencies for gulp build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,10 @@
     "babel-core": "^6.7.4",
     "babel-loader": "^6.2.4",
     "babel-preset-es2015": "^6.6.0",
-    "gulp-umd": "^0.2.0",
+    "browser-sync": "^2.17.5",
+    "del": "^2.2.2",
     "gulp-babel": "^6.1.2",
+    "gulp-umd": "^0.2.0",
     "gulp-watch": "^4.3.5"
   },
   "scripts": {


### PR DESCRIPTION
The `browser-sync` and `del` modules weren't listed in the development dependencies preventing me from running gulp.
